### PR TITLE
recycle dp$color to pass data.table 1.12.2

### DIFF
--- a/R/chart_amBoxplot.R
+++ b/R/chart_amBoxplot.R
@@ -437,8 +437,8 @@ amBoxplot.formula <-function(object, data = NULL, id = NULL, xlab = NULL, ylab =
   if(is.null(col)){
     col <- "#1e90ff"
   }
-  dp$color <- col
-  
+  dp$color <- rep(col, length.out=nrow(dp))  # recyle colors such as c("blue", "red") in test_amBoxplot.R
+
   outliers <- as.list(res[seq(2, nrow(res), by = 2)])
   
   # cat <- as.character(outliers[[1]])


### PR DESCRIPTION
Dear Benoit,

You were one of 16 maintainers I emailed on 24th Jan. You were one of the 3 I didn't hear back from. Hopefully this change in data.table is ok with you.
Background : 
https://twitter.com/MattDowle/status/1088544083499311104
https://github.com/Rdatatable/data.table/pull/3310
https://github.com/Rdatatable/data.table/issues/3347

I've run `R CMD check` on `rAmCharts` with this PR (just one line needs change) and it passes ok.  Will it be ok for you to update rAmCharts on CRAN?

Best, Matt
